### PR TITLE
fix/no-trailing-comma

### DIFF
--- a/tslint.json
+++ b/tslint.json
@@ -41,7 +41,6 @@
     "no-require-imports": false,
     "no-string-literal": false,
     "no-switch-case-fall-through": true,
-    "no-trailing-comma": true,
     "no-trailing-whitespace": true,
     "no-unreachable": true,
     "no-unused-expression": true,
@@ -59,6 +58,7 @@
     "radix": true,
     "semicolon": true,
     "switch-default": true,
+    "trailing-comma": [false],
     "triple-equals": [true, "allow-null-check"],
     "typedef-whitespace": [true, {
       "call-signature": "nospace",

--- a/tslint.json
+++ b/tslint.json
@@ -58,7 +58,7 @@
     "radix": true,
     "semicolon": true,
     "switch-default": true,
-    "trailing-comma": [false],
+    "trailing-comma": [true, {"multiline": "never", "singleline": "never"}],
     "triple-equals": [true, "allow-null-check"],
     "typedef-whitespace": [true, {
       "call-signature": "nospace",


### PR DESCRIPTION
This should fix the no-trailing-comma error tslint is throwing when using tslint version 3.15.1 (get's installed on 4 pc's when running `npm install`).

![image](https://cloud.githubusercontent.com/assets/2146903/20919659/3be002dc-bb9d-11e6-87c2-f76b4a600a80.png)

If we're not supposed to be using tslint 3.15.1, please ignore this PR.
If we're supposed to be using tslint 4.0.2 (as specified in the package.json, but not installed when doing a fresh install) the tslint.json file might need more modifcations.